### PR TITLE
Add toolset manager tests

### DIFF
--- a/src/alibabacloud_rds_openapi_mcp_server/server.py
+++ b/src/alibabacloud_rds_openapi_mcp_server/server.py
@@ -12,7 +12,7 @@ from alibabacloud_rds20140815 import models as rds_20140815_models
 from alibabacloud_tea_openapi import models as open_api_models
 from alibabacloud_tea_util import models as util_models
 from alibabacloud_vpc20160428 import models as vpc_20160428_models
-from mcp.server.fastmcp import FastMCP
+from .toolsets import ToolsetManager, ToolsetMCP
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(current_dir)
@@ -26,7 +26,9 @@ from utils import (transform_to_iso_8601,
 
 logger = logging.getLogger(__name__)
 
-mcp = FastMCP("Alibaba Cloud RDS OPENAPI")
+# Use ToolsetMCP to allow grouping tools
+mcp = ToolsetMCP("Alibaba Cloud RDS OPENAPI")
+toolset_manager = mcp.manager
 
 
 class OpenAPIError(Exception):
@@ -1436,6 +1438,9 @@ async def describe_sql_insight_statistic(
 
 
 def main():
+    from .toolsets.toolsets import initialize_toolsets
+
+    initialize_toolsets(os.getenv('MCP_TOOLSETS'))
     mcp.run(transport=os.getenv('SERVER_TRANSPORT', 'stdio'))
 
 

--- a/src/alibabacloud_rds_openapi_mcp_server/toolsets/__init__.py
+++ b/src/alibabacloud_rds_openapi_mcp_server/toolsets/__init__.py
@@ -1,0 +1,3 @@
+from .toolsets import ToolsetManager, ToolsetMCP
+
+__all__ = ["ToolsetManager", "ToolsetMCP"]

--- a/src/alibabacloud_rds_openapi_mcp_server/toolsets/rds_custom.py
+++ b/src/alibabacloud_rds_openapi_mcp_server/toolsets/rds_custom.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from ..server import mcp
+
+
+@mcp.tool()
+async def custom_echo(text: str) -> str:
+    """Example custom tool that echoes the provided text."""
+    return f"custom echo: {text}"

--- a/src/alibabacloud_rds_openapi_mcp_server/toolsets/tools.py
+++ b/src/alibabacloud_rds_openapi_mcp_server/toolsets/tools.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from types import ModuleType
+
+from .toolsets import ToolsetManager
+
+
+def load_groups(manager: ToolsetManager, server_module: ModuleType) -> None:
+    """Assign selected tools to groups using ``ToolsetManager``."""
+
+    if hasattr(server_module, "describe_db_instances"):
+        manager.set_group(server_module.describe_db_instances, "rds")
+    if hasattr(server_module, "describe_db_instance_attribute"):
+        manager.set_group(server_module.describe_db_instance_attribute, "rds")
+
+    # Load tools defined in separate modules
+    from . import rds_custom
+
+    manager.set_group(rds_custom.custom_echo, "custom")

--- a/src/alibabacloud_rds_openapi_mcp_server/toolsets/toolsets.py
+++ b/src/alibabacloud_rds_openapi_mcp_server/toolsets/toolsets.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+"""Utility classes to manage groups of MCP tools."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Tuple
+
+from mcp.server.fastmcp import FastMCP
+
+
+@dataclass
+class _ToolInfo:
+    func: Callable
+    args: Tuple[Any, ...]
+    kwargs: Dict[str, Any]
+    group: str
+
+
+class ToolsetManager:
+    """Manage tool groups and register them on demand."""
+
+    def __init__(self) -> None:
+        # Mapping of tool function to its metadata for easy regrouping
+        self._tools: Dict[Callable, _ToolInfo] = {}
+        self.groups: Dict[str, List[_ToolInfo]] = {}
+        self.enabled: set[str] = set()
+
+    def add_tool(
+        self,
+        func: Callable,
+        group: str = "default",
+        args: Tuple[Any, ...] | None = None,
+        kwargs: Dict[str, Any] | None = None,
+    ) -> None:
+        """Add a tool to a group without registering it."""
+        if args is None:
+            args = ()
+        if kwargs is None:
+            kwargs = {}
+        info = self._tools.get(func)
+        if info:
+            # remove from previous group list if re-added
+            if info.group in self.groups:
+                self.groups[info.group] = [i for i in self.groups[info.group] if i.func != func]
+        info = _ToolInfo(func=func, args=args, kwargs=kwargs, group=group)
+        self._tools[func] = info
+        self.groups.setdefault(group, []).append(info)
+
+    def set_group(self, func: Callable, group: str) -> None:
+        """Move a registered tool to a different group."""
+        info = self._tools.get(func)
+        if info is None:
+            # tool not registered yet; add directly
+            self.add_tool(func, group=group)
+            return
+        if info.group == group:
+            return
+        # remove from old group
+        old_group = info.group
+        if old_group in self.groups:
+            self.groups[old_group] = [i for i in self.groups[old_group] if i.func != func]
+        info.group = group
+        self.groups.setdefault(group, []).append(info)
+
+    def enable(self, *groups: str) -> None:
+        """Enable one or more groups."""
+        for g in groups:
+            self.enabled.add(g)
+
+    def get_registered_groups(self) -> List[str]:
+        """Return a list of all groups that have tools registered."""
+        return list(self.groups.keys())
+
+    def get_enabled_groups(self) -> List[str]:
+        """Return a list of currently enabled groups."""
+        return list(self.enabled)
+
+    def get_enabled_tools(self) -> Dict[str, List[Callable]]:
+        """Return mapping of enabled group name to its tools."""
+        result: Dict[str, List[Callable]] = {}
+        for name in self.enabled:
+            result[name] = [info.func for info in self.groups.get(name, [])]
+        return result
+
+    def register_enabled(self, mcp: FastMCP) -> None:
+        """Register all tools from enabled groups with the given MCP instance."""
+        for info in self._tools.values():
+            if info.group in self.enabled:
+                FastMCP.tool(mcp, *info.args, **info.kwargs)(info.func)
+
+
+class ToolsetMCP(FastMCP):
+    """FastMCP variant that stores tools in ``ToolsetManager``."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        # Always use a single ``ToolsetManager`` instance per MCP.
+        self.manager = ToolsetManager()
+        super().__init__(*args, **kwargs)
+
+    def tool(self, *dargs: Any, group: str = "default", **dkwargs: Any):
+        """Decorate a tool and store it for later registration."""
+
+        def decorator(func: Callable):
+            self.manager.add_tool(func, group=group, args=dargs, kwargs=dkwargs)
+            return func
+
+        return decorator
+
+    def register_enabled_tools(self) -> None:
+        self.manager.register_enabled(self)
+
+
+def initialize_toolsets(toolsets: list[str] | str | None = None) -> None:
+    """Load tool groups and enable selected sets."""
+
+    from .. import server as _server
+    from .tools import load_groups
+
+    # Assign tools to their groups once at startup
+    load_groups(_server.toolset_manager, _server)
+
+    if toolsets is None:
+        enabled = ["default"]
+    elif isinstance(toolsets, str):
+        enabled = [g.strip() for g in toolsets.split(",") if g.strip()] or ["default"]
+    else:
+        enabled = list(toolsets) or ["default"]
+
+    _server.toolset_manager.enable(*enabled)
+    _server.mcp.register_enabled_tools()

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -1,0 +1,116 @@
+import importlib
+import sys
+from pathlib import Path
+import types
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+# Provide a minimal stub for the ``mcp`` package used during tests.
+fastmcp_stub = types.ModuleType("mcp.server.fastmcp")
+
+class FastMCP:
+    def __init__(self, *args, **kwargs):
+        self._tools = []
+
+    @staticmethod
+    def tool(mcp, *args, **kwargs):
+        def decorator(func):
+            mcp._tools.append(func)
+            return func
+        return decorator
+
+fastmcp_stub.FastMCP = FastMCP
+server_pkg_stub = types.ModuleType("mcp.server")
+server_pkg_stub.fastmcp = fastmcp_stub
+mcp_stub = types.ModuleType("mcp")
+mcp_stub.server = server_pkg_stub
+sys.modules.setdefault("mcp", mcp_stub)
+sys.modules.setdefault("mcp.server", server_pkg_stub)
+sys.modules.setdefault("mcp.server.fastmcp", fastmcp_stub)
+
+from alibabacloud_rds_openapi_mcp_server.toolsets.toolsets import (
+    ToolsetMCP,
+    initialize_toolsets,
+)
+
+
+def make_server_module():
+    """Create a dummy server module with two tools registered."""
+    server = types.ModuleType("alibabacloud_rds_openapi_mcp_server.server")
+    server.mcp = ToolsetMCP("dummy")
+    server.toolset_manager = server.mcp.manager
+
+    @server.mcp.tool()
+    async def describe_db_instances():
+        pass
+
+    @server.mcp.tool()
+    async def describe_db_instance_attribute():
+        pass
+
+    server.describe_db_instances = describe_db_instances
+    server.describe_db_instance_attribute = describe_db_instance_attribute
+
+    sys.modules["alibabacloud_rds_openapi_mcp_server.server"] = server
+    return server
+
+
+def make_rds_custom(server):
+    module = types.ModuleType(
+        "alibabacloud_rds_openapi_mcp_server.toolsets.rds_custom"
+    )
+
+    @server.mcp.tool()
+    async def custom_echo(text: str):
+        return text
+
+    module.custom_echo = custom_echo
+    sys.modules[
+        "alibabacloud_rds_openapi_mcp_server.toolsets.rds_custom"
+    ] = module
+    return module
+
+
+@pytest.fixture(autouse=True)
+def dummy_env(monkeypatch):
+    server = make_server_module()
+    make_rds_custom(server)
+    yield server
+
+
+def test_load_groups_should_assign_tools_to_correct_groups_when_called(dummy_env):
+    server = dummy_env
+    from alibabacloud_rds_openapi_mcp_server.toolsets.tools import load_groups
+
+    load_groups(server.toolset_manager, server)
+
+    groups = server.toolset_manager.groups
+    assert "rds" in groups
+    assert server.describe_db_instances in [i.func for i in groups["rds"]]
+    assert server.describe_db_instance_attribute in [i.func for i in groups["rds"]]
+    assert "custom" in groups
+    assert any(i.func.__name__ == "custom_echo" for i in groups["custom"])
+
+
+def test_initialize_toolsets_should_enable_default_group_when_toolsets_none(dummy_env):
+    server = dummy_env
+
+    initialize_toolsets(None)
+
+    assert server.toolset_manager.enabled == {"default"}
+
+
+def test_manager_should_report_enabled_groups_and_tools_when_queried(dummy_env):
+    server = dummy_env
+    from alibabacloud_rds_openapi_mcp_server.toolsets.tools import load_groups
+
+    load_groups(server.toolset_manager, server)
+    server.toolset_manager.enable("rds", "custom")
+
+    assert set(server.toolset_manager.get_registered_groups()) >= {"default", "rds", "custom"}
+    assert set(server.toolset_manager.get_enabled_groups()) == {"rds", "custom"}
+    enabled = server.toolset_manager.get_enabled_tools()
+    assert "rds" in enabled and server.describe_db_instances in enabled["rds"]
+    assert "custom" in enabled and any(f.__name__ == "custom_echo" for f in enabled["custom"])


### PR DESCRIPTION
## Summary
- expand `ToolsetManager` with listing helpers
- add unit tests for toolset grouping and enabling logic
- remove `manager` parameter from `ToolsetMCP` and create a single manager per instance

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68537ec0dc2883319d82c252f593df41